### PR TITLE
Feature/mdbp 22136 flip default join and cardinality direction

### DIFF
--- a/META.json
+++ b/META.json
@@ -36,7 +36,7 @@
    "provides" : {
       "JoinHero" : {
          "file" : "lib/JoinHero.pm",
-         "version" : "v0.0.1"
+         "version" : "v0.1.0"
       },
       "JoinHero::Logger" : {
          "file" : "lib/JoinHero/Logger.pm"
@@ -48,6 +48,6 @@
          "http://apache.org/licenses/LICENSE-2.0"
       ]
    },
-   "version" : "v0.0.1",
+   "version" : "v0.1.0",
    "x_serialization_backend" : "JSON::PP version 2.27300_01"
 }

--- a/META.yml
+++ b/META.yml
@@ -15,7 +15,7 @@ name: JoinHero
 provides:
   JoinHero:
     file: lib/JoinHero.pm
-    version: v0.0.1
+    version: v0.1.0
   JoinHero::Logger:
     file: lib/JoinHero/Logger.pm
 requires:
@@ -30,5 +30,5 @@ requires:
   perl: v5.10.1
 resources:
   license: http://apache.org/licenses/LICENSE-2.0
-version: v0.0.1
+version: v0.1.0
 x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/script/join-hero
+++ b/script/join-hero
@@ -216,7 +216,9 @@ join-hero
  Options:
   'i|file|inputFilepath=s'       DDL File input file with key info [required]
   'o|out|outputFilepath=s'       Output filepath for metadata sql [required]
-  'types=s'                      Comma delimited list of application types. Defaults to 'SAMPLE'
+  'types=s'                      Comma delimited list in the form app[:direction]. Will generate one
+                                  set of metadata per app. If direction is 'REVERSED', 'from' and 'to' 
+                                  direction is flipped. Defaults to 'SAMPLE'.
   'marts|martPrefixes=s'         Comma delimited list of prefixes for schema derivation [optional]
   'u|updateExisting'             Update existing metadata [optional]
   'd|deleteExisting'             Delete existing metadata [optional]


### PR DESCRIPTION
Flipping default to/from directions. Adding ability to override direction with types option.

New types usage:

      'types=s'              Comma delimited list in the form app[:direction]. Will generate one
                                      set of metadata per app. If direction is 'REVERSED', 'from' and 'to'
                                      direction is flipped. Defaults to 'SAMPLE'.
