### PR TITLE
[MDBP-21163][MDBP-22942] Updated internal keying to avoid de-dupe

### DIFF
--- a/META.json
+++ b/META.json
@@ -36,7 +36,7 @@
    "provides" : {
       "JoinHero" : {
          "file" : "lib/JoinHero.pm",
-         "version" : "v0.1.5"
+         "version" : "v0.1.6"
       },
       "JoinHero::Logger" : {
          "file" : "lib/JoinHero/Logger.pm"
@@ -48,6 +48,6 @@
          "http://apache.org/licenses/LICENSE-2.0"
       ]
    },
-   "version" : "v0.1.5",
+   "version" : "v0.1.6",
    "x_serialization_backend" : "JSON::PP version 2.27300_01"
 }

--- a/META.yml
+++ b/META.yml
@@ -15,7 +15,7 @@ name: JoinHero
 provides:
   JoinHero:
     file: lib/JoinHero.pm
-    version: v0.1.5
+    version: v0.1.6
   JoinHero::Logger:
     file: lib/JoinHero/Logger.pm
 requires:
@@ -30,5 +30,5 @@ requires:
   perl: v5.10.1
 resources:
   license: http://apache.org/licenses/LICENSE-2.0
-version: v0.1.5
+version: v0.1.6
 x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,22 +3,22 @@ require 5.010001;
 use ExtUtils::MakeMaker;
 WriteMakefile
 (
-  'INSTALLDIRS' => 'site',
-  'PL_FILES' => {},
   'PREREQ_PM' => {
-                   'Pod::Usage' => '0',
-                   'File::Glob' => '0',
+                   'Getopt::Long' => '0',
                    'Log::Log4perl' => '0',
+                   'File::Path' => '0',
                    'Cwd' => '0',
                    'IO::Handle' => '0',
-                   'File::Path' => '0',
+                   'Pod::Usage' => '0',
                    'Data::Dumper' => '0',
-                   'Getopt::Long' => '0'
+                   'File::Glob' => '0'
                  },
+  'INSTALLDIRS' => 'site',
   'VERSION_FROM' => 'lib/JoinHero.pm',
-  'NAME' => 'JoinHero',
+  'PL_FILES' => {},
   'EXE_FILES' => [
                    'script/join-hero'
-                 ]
+                 ],
+  'NAME' => 'JoinHero'
 )
 ;

--- a/t/10-parsing.t
+++ b/t/10-parsing.t
@@ -52,15 +52,16 @@ sub getTableName {
 sub fkBreakOut {
 
   # Let's make sure this FK broke out like we expected
-  ok($fk_01->{S_SL_FK}->{fromTable} eq 'STORES');
-  ok($fk_01->{S_SL_FK}->{toTable} eq 'STORE_LOCATIONS');
-  ok($fk_01->{S_SL_FK}->{fromSchema} eq 'JJJ');
-  ok($fk_01->{S_SL_FK}->{toSchema} eq 'JJJ');
-  ok($fk_01->{S_SL_FK}->{fromFields} ~~ ['LOCATION_ID']);
-  ok($fk_01->{S_SL_FK}->{toFields}   ~~ ['LOCATION_ID']);
-  ok($fk_01->{S_SL_FK}->{fromFieldList} eq 'LOCATION_ID');
-  ok($fk_01->{S_SL_FK}->{toFieldList} eq 'LOCATION_ID');
-  ok($fk_01->{S_SL_FK}->{fkName} eq 'S_SL_FK');
+  my $fkKey = 'S_SL_FK-_-JJJ.STORES-_-JJJ.STORE_LOCATIONS';
+  ok($fk_01->{$fkKey}->{fromTable} eq 'STORES');
+  ok($fk_01->{$fkKey}->{toTable} eq 'STORE_LOCATIONS');
+  ok($fk_01->{$fkKey}->{fromSchema} eq 'JJJ');
+  ok($fk_01->{$fkKey}->{toSchema} eq 'JJJ');
+  ok($fk_01->{$fkKey}->{fromFields} ~~ ['LOCATION_ID']);
+  ok($fk_01->{$fkKey}->{toFields}   ~~ ['LOCATION_ID']);
+  ok($fk_01->{$fkKey}->{fromFieldList} eq 'LOCATION_ID');
+  ok($fk_01->{$fkKey}->{toFieldList} eq 'LOCATION_ID');
+  ok($fk_01->{$fkKey}->{fkName} eq 'S_SL_FK');
 
   return;
 } ## end sub fkBreakOut
@@ -81,19 +82,20 @@ sub pkBreakOut {
 sub getJoinCardinality {
 
   # Just S_SL_FK by itself with no matching target pk/uk should result in a 'MANY' cardinality
+  my $fkKey = 'S_SL_FK-_-JJJ.STORES-_-JJJ.STORE_LOCATIONS';
   my ($pk_02, $fk_02) = JoinHero::getKeyComponents("$s_sl_fk");
-  ok(JoinHero::getJoinCardinality($pk_02, $fk_02->{S_SL_FK}) eq 'MANY');
+  ok(JoinHero::getJoinCardinality($pk_02, $fk_02->{$fkKey}) eq 'MANY');
 
   # S_SL_FK with a matching target pk/uk should result in a 'ONE' cardinality
   my ($pk_03, $fk_03) = JoinHero::getKeyComponents("$s_sl_fk \n $stores_locations_pk");
-  ok(JoinHero::getJoinCardinality($pk_03, $fk_03->{S_SL_FK}) eq 'ONE');
+  ok(JoinHero::getJoinCardinality($pk_03, $fk_03->{$fkKey}) eq 'ONE');
 
   # If the join order is flipped, we would expect a 'MANY' cardinality
-  ok(JoinHero::getJoinCardinality($pk_03, $fk_03->{S_SL_FK}, 'from') eq 'MANY');
-  ok(JoinHero::getJoinCardinality($pk_03, $fk_03->{S_SL_FK}, 'REVERSED') eq 'MANY');
+  ok(JoinHero::getJoinCardinality($pk_03, $fk_03->{$fkKey}, 'from') eq 'MANY');
+  ok(JoinHero::getJoinCardinality($pk_03, $fk_03->{$fkKey}, 'REVERSED') eq 'MANY');
 
   # Make sure we get something back if we supply a nonsense direction
-  ok(JoinHero::getJoinCardinality($pk_03, $fk_03->{S_SL_FK}, 'Sideways') eq 'INVALID_DIRECTION');
+  ok(JoinHero::getJoinCardinality($pk_03, $fk_03->{$fkKey}, 'Sideways') eq 'INVALID_DIRECTION');
 
   return;
 } ## end sub getJoinCardinality
@@ -180,7 +182,7 @@ sub sqlGenerationS_SL_FKBasic {
   };
 
   # Let's test getJoinSQL. This guy uses component hash refs to generate merge SQL for a particular join
-  my $fkKey              = $fk_01->{S_SL_FK}->{fkName};
+  my $fkKey              = 'S_SL_FK-_-JJJ.STORES-_-JJJ.STORE_LOCATIONS';
   my $getJoinSQLParams   = {pkComponents => $pk_01, fkComponents => $fk_01};
   my $getJoinSQL_S_SL_FK = JoinHero::getJoinSQL($fkKey, $getJoinSQLParams);
   ok(whitespaceInsensitiveCompare($getJoinSQL_S_SL_FKExpectedSQL, $getJoinSQL_S_SL_FK));


### PR DESCRIPTION
Updated fkKeying to de-dupe on and us a concat of "$fkName-_-$fromTable-_-$toTable". The modeler tool allows for duplicate fk names which allows for joins to get deduplicated