### PR TITLE
Fixing issues with .dockerignore for *Nix systems

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,16 +11,16 @@
 *.tape
 *.temp
 *.zip
-\debug
+/debug
 *.bk
-\Cheap Hack
+/Cheap Hack
 *.csv
 *.txt
-\datamodeler
-\exp
-\scratch
-\bin
-\logs
+/datamodeler
+/exp
+/scratch
+/bin
+/logs
 join_us.sql
 
 


### PR DESCRIPTION
*Nix System like Amazon Linux 2 don't like backslashes in the .dockerignore file as it turns out. It causes docker to throw the following less than helpful error message:

```bash
$ docker build -t 'join-hero:aws_testing' /home/ec2-user/git/join-hero/
error checking context: 'syntax error in pattern'.
```
